### PR TITLE
Adds getETA support

### DIFF
--- a/github-issue-get-eta.go
+++ b/github-issue-get-eta.go
@@ -1,0 +1,81 @@
+/*
+ * Buzz, (C) 2016,2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"encoding/json"
+	"strings"
+)
+
+type eta_struct struct {
+	ETA, Err string
+}
+var eta eta_struct
+func getETAFromComment(org string, repo string, id int) {
+
+	var comments []string
+	iComments, _, err := buzzClient.Issues.ListComments(ctx, org, repo, id, nil)
+	if err != nil {
+		fmt.Printf("Unable to get comment. Error: \"%s\"\n", err)
+		if strings.Contains(err.Error(), "404 Not Found") {
+			fmt.Println("Entered", !strings.Contains(err.Error(), "404 Not Found"))
+			eta = eta_struct{"", "404 Not Found"}
+			return
+		}
+	}
+	for _, comment := range iComments {
+		comments = append(comments, comment.GetBody())
+	}
+	if len(comments) == 0 {
+		eta = eta_struct{"", "No Comments Found"}
+		return
+	}
+	re := regexp.MustCompile(`ETA: (20(1[7-9]|[2-9][0-9])-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) (0[1-9]|1[0-9]|2[0-3]):[0-5][0-9])`)
+	for i:=len(comments)-1; i>=0; i-- {
+		match := re.FindStringSubmatch(comments[i])
+		fmt.Println("match", match, len(match))
+		if len(match) > 0 {
+			eta = eta_struct{match[1], ""}
+			return
+		}
+	}
+}
+
+func getETA(w http.ResponseWriter, req *http.Request) {
+	org := req.URL.Query().Get("org")
+	repo := req.URL.Query().Get("repo")
+	id_str := req.URL.Query().Get("id")
+	id_int, err := strconv.Atoi(id_str)
+	if err!= nil || id_int == 0 || org == "" || repo == "" {
+		fmt.Println("Missing/Wrong argument(s) in your URL!")
+		fmt.Println("Expected: ../getETA?org=<org>&repo=<repo>&id=<id>")
+		fmt.Println("Received: ../getETA?org=\""+org+"\"&repo=\""+repo+"\"&id=\""+id_str+"\".")
+	} else {
+		getETAFromComment(org,repo, id_int)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	js, err := json.Marshal(eta)
+	if err != nil {
+		fmt.Print(err)
+		return
+	}
+	w.Write(js)
+}

--- a/github-issue-get-eta.go
+++ b/github-issue-get-eta.go
@@ -17,67 +17,70 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
-	"regexp"
-	"strconv"
-	"encoding/json"
-	"strings"
+    "fmt"
+    "net/http"
+    "regexp"
+    "strconv"
+    "encoding/json"
+    "strings"
 )
 
-type eta_struct struct {
-	ETA, Error string
+type ETAStruct struct {
+    ETA, Error string
 }
-var eta eta_struct
-func getETAFromComment(org string, repo string, id int) {
+func getETAFromComment(org string, repo string, id int) ETAStruct {
 
-	var comments []string
-	iComments, _, err := buzzClient.Issues.ListComments(ctx, org, repo, id, nil)
-	if err != nil {
-		fmt.Printf("Unable to get comment. Error: \"%s\"\n", err)
-		if strings.Contains(err.Error(), "404 Not Found") {
-			eta = eta_struct{"", "Issue Not Found"}
-			return
-		}
-	}
-	for _, comment := range iComments {
-		comments = append(comments, comment.GetBody())
-	}
-	if len(comments) == 0 {
-		eta = eta_struct{"", "No Comments Found"}
-		return
-	}
-	re := regexp.MustCompile(`ETA: (20(1[7-9]|[2-9][0-9])-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) (0[1-9]|1[0-9]|2[0-3]):[0-5][0-9])`)
-	for i:=len(comments)-1; i>=0; i-- {
-		match := re.FindStringSubmatch(comments[i])
-		if len(match) > 0 {
-			eta = eta_struct{match[1], ""}
-			return
-		}
-	}
-	eta = eta_struct{"", "No ETA Specified"}
-	return
+    var comments []string
+    var eta ETAStruct
+    iComments, _, err := buzzClient.Issues.ListComments(ctx, org, repo, id, nil)
+    if err != nil {
+        fmt.Printf("Unable to get comment. Error: \"%s\"\n", err)
+        if strings.Contains(err.Error(), "404 Not Found") {
+            eta = ETAStruct{"", "Issue Not Found"}
+       }
+    } else {
+        for _, comment := range iComments {
+            comments = append(comments, comment.GetBody())
+        }
+        if len(comments) == 0 {
+            eta = ETAStruct{"", "No Comments Found"}
+        } else {
+            re := regexp.MustCompile(`ETA: (20(1[7-9]|[2-9][0-9])-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) (0[1-9]|1[0-9]|2[0-3]):[0-5][0-9])`)
+            for i:=len(comments)-1; i>=0; i-- {
+                match := re.FindStringSubmatch(comments[i])
+                if len(match) > 0 {
+                    eta = ETAStruct{match[1], ""}
+                }
+            }
+            if eta.ETA == "" {
+                eta = ETAStruct{"", "No ETA Specified"}
+            }
+        }
+    }
+    return eta
 }
 
 func getETA(w http.ResponseWriter, req *http.Request) {
-	org := req.URL.Query().Get("org")
-	repo := req.URL.Query().Get("repo")
-	id_str := req.URL.Query().Get("id")
-	id_int, err := strconv.Atoi(id_str)
-	
-	if err!= nil || id_int == 0 || org == "" || repo == "" {
-		fmt.Println("Missing/Wrong argument(s) in your URL!")
-		fmt.Println("Expected: ../getETA?org=<org>&repo=<repo>&id=<id>")
-		fmt.Println("Received: ../getETA?org=\""+org+"\"&repo=\""+repo+"\"&id=\""+id_str+"\".")
-		eta = eta_struct{"", "Wrong ARGs"}
-	} else {
-		getETAFromComment(org,repo, id_int)
-	}
-	w.Header().Set("Content-Type", "application/json")
-	js, err := json.Marshal(eta)
-	if err != nil {
-		fmt.Print(err)
-		return
-	}
-	w.Write(js)
+    org := req.URL.Query().Get("org")
+    repo := req.URL.Query().Get("repo")
+    id_str := req.URL.Query().Get("id")
+    id_int, err := strconv.Atoi(id_str)
+
+    var eta ETAStruct
+
+    if err!= nil || id_int == 0 || org == "" || repo == "" {
+        fmt.Println("Missing/Wrong argument(s) in your URL!")
+        fmt.Println("Expected: ../getETA?org=<org>&repo=<repo>&id=<id>")
+        fmt.Println("Received: ../getETA?org=\""+org+"\"&repo=\""+repo+"\"&id=\""+id_str+"\".")
+        eta = ETAStruct{"", "Wrong ARGs"}
+    } else {
+        eta = getETAFromComment(org,repo, id_int)
+    }
+    w.Header().Set("Content-Type", "application/json")
+    js, err := json.Marshal(eta)
+    if err != nil {
+        fmt.Print(err)
+        return
+    }
+    w.Write(js)
 }

--- a/github-issues.go
+++ b/github-issues.go
@@ -63,6 +63,9 @@ type RepoIssues struct {
 		Color   string `json:"color"`
 		Default bool   `json:"default"`
 	} `json:"labels"`
+	Assignee struct {
+		Login string `json:"login"`
+	} `json:"assignee"`
 	Assignees []struct {
 		Login string `json:"login"`
 	} `json:"assignees"`
@@ -93,9 +96,10 @@ func populateIssues(url string) {
 	mIssues := []RepoIssues{}
 	json.Unmarshal(htmlData, &mIssues)
 
-	var flag int
 	// iterate through each issue and scrape what buzz needs.
 	for _, elem := range mIssues {
+		// var declaration automatically initialize flag var to 0
+		var flag int
 		eachGitIssue := GitIssues{}
 
 		if elem.PullRequest.URL != "" {

--- a/github-issues.go
+++ b/github-issues.go
@@ -63,9 +63,6 @@ type RepoIssues struct {
 		Color   string `json:"color"`
 		Default bool   `json:"default"`
 	} `json:"labels"`
-	Assignee struct {
-		Login string `json:"login"`
-	} `json:"assignee"`
 	Assignees []struct {
 		Login string `json:"login"`
 	} `json:"assignees"`
@@ -97,7 +94,6 @@ func populateIssues(url string) {
 	json.Unmarshal(htmlData, &mIssues)
 
 	var flag int
-
 	// iterate through each issue and scrape what buzz needs.
 	for _, elem := range mIssues {
 		eachGitIssue := GitIssues{}
@@ -129,10 +125,6 @@ func populateIssues(url string) {
 		}
 		if flag != 1 {
 			gIssues = append(gIssues, eachGitIssue)
-			flag = 0
-		} else {
-			// this is not an open issue so don't do anything but continue.
-			flag = 0
 		}
 	} // end of for
 }

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 	http.HandleFunc("/getIssues", getIssues)
 	http.HandleFunc("/getPRs", getPRs)
 	http.HandleFunc("/setETA", setComment)
+	http.HandleFunc("/getETA", getETA)
 
 	fs := http.FileServer(http.Dir("static"))
 	http.Handle("/", fs)
@@ -80,6 +81,7 @@ func main() {
 			log.Fatal("ListenAndServe: ", err)
 		}
 	} else {
+		fmt.Println("About to start server on port 7000")
 		log.Fatalln(http.ListenAndServe(":7000", nil))
 	}
 }


### PR DESCRIPTION
Issue#48
This change parses and displays in Jason format the last ETA set for a given issue.

3 parameters are required to be provided at URL; organization name, repository name and the issue id as shown below: 
../getETA?org=<org>&repo=<repo>&id=<id>

Also included is the clean up changes of some obsolete code from the main.go file