### PR TITLE
clean up age, updated_at

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $ yarn build
 
 ```
 $ go build
+$ go get -v ./...
 $ GIT_TOKEN="YOUR GITHUB ACCESS TOKEN" ./buzz
 ```
 

--- a/github-issues.go
+++ b/github-issues.go
@@ -40,9 +40,8 @@ type GitIssues struct {
 	Milestone string `json:"milestone"`
 	State     string `json:"state"`
 	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	UpdatedAt int64  `json:"updated_at"`
 	Repo      string `json:"repository_url"`
-	Hours     int64  `json:"hours"`
 }
 
 // RepoIssues - holds all issues per repo.
@@ -110,9 +109,7 @@ func populateIssues(url string) {
 			eachGitIssue.Repo = elem.RepositoryURL
 			eachGitIssue.Link = elem.HTMLURL
 			eachGitIssue.CreatedAt = elem.CreatedAt.Format(buzzTimeLayout)
-			eachGitIssue.UpdatedAt = elem.UpdatedAt.Format(buzzTimeLayout)
-			delta := elem.UpdatedAt.Sub(elem.CreatedAt)
-			eachGitIssue.Hours = int64(delta.Hours())
+			eachGitIssue.UpdatedAt = elem.UpdatedAt.Unix()
 
 			// iterate to get all labels and colors.
 			for _, labe := range elem.Labels {

--- a/github-pull-requests.go
+++ b/github-pull-requests.go
@@ -33,10 +33,9 @@ type GitPRs struct {
 	Sender      string `json:"sender"`
 	Assignees   string `json:"login"`
 	State       string `json:"state"`
-	UpdatedAt   string `json:"updated_at"`
+	UpdatedAt   int64  `json:"updated_at"`
 	Repo        string `json:"repo_name"`
 	Link        string `json:"html_url"`
-	Hours       int64  `json:"hours"`
 	Reviewers   []ReviewStatus
 	ReviewState []ReviewState
 }
@@ -92,9 +91,7 @@ func populatePRs(rName string, url string) {
 		for _, assignee := range elem.Assignees {
 			eachPRIssue.Assignees += assignee.Login + " "
 		}
-		eachPRIssue.UpdatedAt = elem.UpdatedAt.Format(buzzTimeLayout)
-		delta := elem.UpdatedAt.Sub(elem.CreatedAt)
-		eachPRIssue.Hours = int64(delta.Hours())
+		eachPRIssue.UpdatedAt = elem.UpdatedAt.Unix()
 		eachPRIssue.Repo = elem.Head.Repo.Name
 		eachPRIssue.ID = elem.ID
 		eachPRIssue.Link = elem.HTMLURL

--- a/static/index.html
+++ b/static/index.html
@@ -46,7 +46,7 @@
                                 <th width="150">Assignee</th>
                                 <th width="150">Milestone</th>
                                 <th width="100">State</th>
-                                <th width="100">Age (in hours)</th>
+                                <th width="100">Last Updated</th>
                                 <th>Repo</th>
                                 <th>ETA</th>
                             </tr>
@@ -62,6 +62,7 @@
         <script src="vendors/bower_components/flatpickr/dist/flatpickr.min.js"></script>
         <script src="vendors/bower_components/pnotify/dist/pnotify.js"></script>
         <script src="vendors/bower_components/pnotify/dist/pnotify.animate.js"></script>
+        <script src="vendors/bower_components/moment/min/moment.min.js"></script>
         <script src="js/tab.js"></script>
         <script src="js/functions.js"></script>
     </body>

--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -54,7 +54,10 @@ $(document).ready(function () {
             { data : "login" },
             { data : "milestone"},
             { data : "state" },
-            { data : "hours"},
+            {
+                data : "updated_at",
+                render: convertDate
+            },
             { data : "repository_url"}
         ],
         "columnDefs": [
@@ -87,8 +90,10 @@ $(document).ready(function () {
             { data : "number" },
             { data : "title" },
             { data : "sender"},
-            { data : "updated_at"},
-            { data : "hours"},
+            {
+                data : "updated_at",
+                render: convertDate
+            },
             { data : "repo_name"},
             {
                 data : "Reviewers",
@@ -123,6 +128,13 @@ $(document).ready(function () {
         ]
     });
 
+    function convertDate(data, type) {
+        // For sorting, cast it to a number.
+        if (type == "sort" || type == "type")
+            return +data;
+
+        return moment.unix(data).fromNow();
+    }
 
     // Refresh data tables
     setInterval(function () {

--- a/static/pull-requests.html
+++ b/static/pull-requests.html
@@ -41,8 +41,7 @@
                                 <th width="5">ID</th>
                                 <th width="20">Description</th>
                                 <th width="5">Sender</th>
-                                <th width="10">Updated At</th>
-                                <th width="5">Age (in hours)</th>
+                                <th width="10">Last Updated</th>
                                 <th width="10">Repo Name</th>
                                 <th width="10">Pending Review</th>
                                 <th width="35">Review Activity</th>
@@ -57,6 +56,7 @@
         <script src="vendors/bower_components/col-resizable/colResizable-1.6.min.js"></script>
         <script src="vendors/bower_components/datatables.net/js/jquery.dataTables.js"></script>
         <script src="vendors/bower_components/flatpickr/dist/flatpickr.min.js"></script>
+        <script src="vendors/bower_components/moment/min/moment.min.js"></script>
         <script src="js/tab.js"></script>
         <script src="js/functions.js"></script>
     </body>

--- a/static/vendors/bower.json
+++ b/static/vendors/bower.json
@@ -31,6 +31,7 @@
     "flatpickr": "flatpickr-calendar#^2.6.1",
     "material-design-iconic-font": "^2.2.0",
     "pnotify": "^3.2.0",
-    "animate.css": "^3.5.2"
+    "animate.css": "^3.5.2",
+    "moment": "^2.18.1"
   }
 }


### PR DESCRIPTION
This commit cleans up the age and updated_at fields. It now uses dates
that are relevant to now instead of hours (i.e. "six days ago", "four
hours ago", "one month ago"). It also uses the correct dates now, as age
used to use the time between the created_at date and the updated_at
date. It now sorts the dates correctly as well.

Unrelated, it adds `go get` to the readme, which is required to build
the software.

It adds a new dependency, momentjs, a very handy date management tool to generate the humanized dates.

Fixes: https://github.com/minio/buzz/issues/57