### PR TITLE
merge reviewers, review activity into colored tags

### DIFF
--- a/github-get-reviewers.go
+++ b/github-get-reviewers.go
@@ -16,14 +16,11 @@
 
 package main
 
-import "fmt"
+import (
+	"time"
 
-// ReviewStatus - holds Review info
-type ReviewStatus struct {
-	User struct {
-		Login string `json:"login"`
-	} `json:"user"`
-}
+	"github.com/google/go-github/github"
+)
 
 // ReviewState - holds each PRs Reviewer's state
 type ReviewState struct {
@@ -33,38 +30,67 @@ type ReviewState struct {
 	State string `json:"state"`
 }
 
-var rStatus []ReviewStatus
-var rReviews []ReviewState
+func getReviewStatesForPR(repo string, number int) (error, []ReviewState) {
+	reviews := make(map[string]*github.PullRequestReview)
 
-func getReviewers(repo string, number int) []ReviewStatus {
-	rStatus = nil
 	// List all reviewers to an assigned PR # in a repo.
-	rList, _, err := buzzClient.PullRequests.ListReviewers(ctx, "minio", repo, number, nil)
+	reviewers, _, err := buzzClient.PullRequests.ListReviewers(ctx, "minio", repo, number, nil)
 	if err != nil {
-		// We should not exit on error in this case.
-		fmt.Println("Unable to get Reviewers for %s", number)
+		return err, nil
 	}
-	for _, elem := range rList {
-		eachReviewer := ReviewStatus{}
-		eachReviewer.User.Login = elem.GetLogin()
-		rStatus = append(rStatus, eachReviewer)
-	}
-	return rStatus
-}
 
-func getReviewStatesForPR(repo string, number int) []ReviewState {
-	rReviews = nil
-	// List all reviewers to an assigned PR # in a repo.
-	rList, _, err := buzzClient.PullRequests.ListReviews(ctx, "minio", repo, number, nil)
+	for _, elem := range reviewers {
+		review := &github.PullRequestReview{}
+		review.User = elem
+
+		// Any reviews are later than this assignment, so put it farthest back.
+		assignDate := time.Unix(0, 0)
+		review.SubmittedAt = &assignDate
+
+		// Assume their review is pending until further notice.
+		status := "PENDING"
+		review.State = &status
+
+		reviews[elem.GetLogin()] = review
+	}
+
+	// List all who voluntarily gave a review.
+	voluntaryReviews, _, err := buzzClient.PullRequests.ListReviews(ctx, "minio", repo, number, nil)
 	if err != nil {
-		// We should not exit on error in this case.
-		fmt.Println("Unable to get Reviewers for %s", number)
+		return err, nil
 	}
-	for _, elem := range rList {
-		eachReview := ReviewState{}
-		eachReview.User.Login = elem.User.GetLogin()
-		eachReview.State = elem.GetState()
-		rReviews = append(rReviews, eachReview)
+
+	for _, elem := range voluntaryReviews {
+		// Ignore comments, without a true review they cannot change status.
+		if elem.GetState() == "COMMENTED" {
+			continue
+		}
+
+		username := elem.User.GetLogin()
+
+		if _, ok := reviews[username]; ok {
+			// If they've been assigned previously and are
+			// continuing with their review, compare the time of this
+			// review to their previous review, replacing it if it's newer.
+			if reviews[username].SubmittedAt.Before(*elem.SubmittedAt) {
+				reviews[username] = elem
+			}
+		} else {
+			// If a user was not assigned but has given a review anyways,
+			// add their review.
+			reviews[username] = elem
+		}
 	}
-	return rReviews
+
+	// Convert the map to an array.
+	rReviews := make([]ReviewState, 0, len(reviews))
+	for username, latest := range reviews {
+		rReview := ReviewState{}
+		rReview.User.Login = username
+		rReview.State = latest.GetState()
+
+		rReviews = append(rReviews, rReview)
+	}
+
+	return nil, rReviews
 }

--- a/github-pull-requests.go
+++ b/github-pull-requests.go
@@ -36,7 +36,6 @@ type GitPRs struct {
 	UpdatedAt   int64  `json:"updated_at"`
 	Repo        string `json:"repo_name"`
 	Link        string `json:"html_url"`
-	Reviewers   []ReviewStatus
 	ReviewState []ReviewState
 }
 
@@ -95,8 +94,12 @@ func populatePRs(rName string, url string) {
 		eachPRIssue.Repo = elem.Head.Repo.Name
 		eachPRIssue.ID = elem.ID
 		eachPRIssue.Link = elem.HTMLURL
-		eachPRIssue.Reviewers = getReviewers(eachPRIssue.Repo, eachPRIssue.Number)
-		eachPRIssue.ReviewState = getReviewStatesForPR(eachPRIssue.Repo, eachPRIssue.Number)
+		err, states := getReviewStatesForPR(eachPRIssue.Repo, eachPRIssue.Number)
+		if err != nil {
+			fmt.Printf("error occurred in getReviewStatesForPR(): %s\n", err.Error())
+		}
+		eachPRIssue.ReviewState = states
+
 		pRequests = append(pRequests, eachPRIssue)
 	} // end of for
 }

--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -96,33 +96,26 @@ $(document).ready(function () {
             },
             { data : "repo_name"},
             {
-                data : "Reviewers",
-                "render": function(data) {
-                    if(data !== null) {
-                        var reviewer = '';
-                        $.each(data, function(k, value) {
-                            reviewer += "<div class='tableTables__tag tableTables__tag--default'>" + value.user.login + "</div>";
-                        });
-                        return reviewer;
-                    }
-                    else {
-                        return "";
-                    }
-                }
-            },
-            {
                 data : "ReviewState",
                 "render": function(data) {
-                    if(data !== null) {
-                        var reviewActivity = '';
-                        $.each(data, function(k, value) {
-                            reviewActivity += "<div class='tableTables__tag tableTables__tag--default'>" + value.user.login + " : "+ value.state + "</div>";
-                        });
-                        return reviewActivity;
-                    }
-                    else {
-                        return "";
-                    }
+                    if (!data) return '';
+
+                    var reviewActivity = '';
+
+                    $.each(data, function(k, value) {
+                        var tagColor;
+                        if (value.state == 'APPROVED')
+                            tagColor = '#1c7527';
+                        else if (value.state == 'CHANGES_REQUESTED')
+                            tagColor = '#dc322f';
+                        else
+                            tagColor = '#a09800'; // pending
+
+
+                        reviewActivity += "<div class='tableTables__tag' style='background-color:"+tagColor+"'>" + value.user.login + "</div>";
+                    });
+
+                    return reviewActivity;
                 }
             }
         ]

--- a/static/pull-requests.html
+++ b/static/pull-requests.html
@@ -43,8 +43,7 @@
                                 <th width="5">Sender</th>
                                 <th width="10">Last Updated</th>
                                 <th width="10">Repo Name</th>
-                                <th width="10">Pending Review</th>
-                                <th width="35">Review Activity</th>
+                                <th width="35">Reviewers</th>
                             </tr>
                         </thead>
                     </table>


### PR DESCRIPTION


This commit merges the reviewers and review activity sections of the
table. Now, it lists all users who have been requested for a review or
have begun a review voluntarily. The status of their review is visible
in the color of their tag. Pending for yellow, accepted for green, or
requested changes for red.

Fixes: https://github.com/minio/buzz/issues/58

screenshot of the change:
![screen shot 2017-07-07 at 5 01 36 pm](https://user-images.githubusercontent.com/3038254/27980936-fb8f42d0-6338-11e7-8053-36fb7287ba86.png)