### PR TITLE
add ETA into issue table

### DIFF
--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -58,13 +58,17 @@ $(document).ready(function () {
                 data : "updated_at",
                 render: convertDate
             },
-            { data : "repository_url"}
-        ],
-        "columnDefs": [
+            { data : "repository_url"},
             {
-                "targets": [ 8 ],
-                "data": null,
-                "defaultContent": "<div class='set-eta'><input class='set-eta__input' type='text' placeholder='Set ETA' /></div>"
+                targets: [ 8 ],
+                data: "eta",
+                render: function(data) {
+                    if (data) {
+                        return data;
+                    } else {
+                        return "<div class='set-eta'><input class='set-eta__input' type='text' placeholder='Set ETA' /></div>";
+                    }
+                }
             }
         ],
         "initComplete": function (settings, json) {


### PR DESCRIPTION
This commit adds the ETA field into the data table.
For every issue, it lists all the comments, parses them for the ETA date
(courtesy of fcf8596), and now it puts that date into the table instead
of the "Set ETA" link.

Fixes: https://github.com/minio/buzz/issues/54