### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -189,7 +189,7 @@ $(document).ready(function () {
             tableData = dataTableIssues.row(this).data()
             tableDataID = tableData["number"];
             var tableDataURL = tableData["repository_url"];
-            tableDataRepo = tableDataURL.substr(tableData["repository_url"].lastIndexOf('/') + 1);
+            tableDataRepo = tableDataURL.slice(tableData["repository_url"].lastIndexOf('/') + 1);
         }
 
         // Open Issue link in new tab


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.